### PR TITLE
Add basic GCP resource inventory script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # GCPRI
-GCP Resource Inventory
+
+GCP Resource Inventory (GCPRI) is a simple utility for collecting an
+inventory of GCP resources across one or more projects. It uses the
+[Cloud Asset API](https://cloud.google.com/asset-inventory/docs/apis) to
+query all resources and outputs the results as JSON or CSV.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+You must also ensure that the Cloud Asset API is enabled and that the
+calling account has sufficient permissions (typically `roles/viewer`).
+
+## Usage
+
+```bash
+python -m gcpri PROJECT_ID [ANOTHER_PROJECT] --output inventory.json
+```
+
+Use `--format csv` to output a CSV file instead of JSON.

--- a/gcpri/__main__.py
+++ b/gcpri/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/gcpri/main.py
+++ b/gcpri/main.py
@@ -1,0 +1,71 @@
+import argparse
+import json
+from typing import List, Dict
+
+from google.cloud import asset_v1
+
+
+def list_assets(project_id: str) -> List[Dict]:
+    client = asset_v1.AssetServiceClient()
+    scope = f"projects/{project_id}"
+    assets = []
+    request = asset_v1.ListAssetsRequest(
+        parent=scope,
+        content_type=asset_v1.ContentType.RESOURCE,
+    )
+    for asset in client.list_assets(request=request):
+        assets.append(
+            {
+                "asset_type": asset.asset_type,
+                "name": asset.name,
+                "project": project_id,
+                "location": asset.resource.location,
+            }
+        )
+    return assets
+
+
+def write_output(records: List[Dict], output_format: str, output_path: str):
+    if output_format == "json":
+        with open(output_path, "w") as fh:
+            json.dump(records, fh, indent=2)
+    elif output_format == "csv":
+        import csv
+
+        if records:
+            fieldnames = list(records[0].keys())
+        else:
+            fieldnames = []
+        with open(output_path, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(records)
+    else:
+        raise ValueError(f"Unsupported format: {output_format}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GCP Resource Inventory")
+    parser.add_argument("project_ids", nargs="+", help="GCP project IDs to inventory")
+    parser.add_argument(
+        "--format",
+        choices=["json", "csv"],
+        default="json",
+        help="Output format",
+    )
+    parser.add_argument("--output", required=True, help="Output file path")
+    args = parser.parse_args()
+
+    all_records = []
+    for pid in args.project_ids:
+        print(f"Collecting assets for {pid}...")
+        records = list_assets(pid)
+        print(f"Found {len(records)} assets in {pid}")
+        all_records.extend(records)
+
+    write_output(all_records, args.format, args.output)
+    print(f"Wrote {len(all_records)} records to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+google-cloud-asset
+pandas


### PR DESCRIPTION
## Summary
- implement a simple command-line utility in `gcpri` to list assets from the Cloud Asset API
- provide package entry point and requirements
- document installation and usage in README

## Testing
- `python -m py_compile gcpri/main.py gcpri/__main__.py gcpri/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684a7a25db28832092e761e1e51a560f