### PR TITLE
Add package metadata and ignore defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Virtual environments
+.env/
+.venv/
+venv/
+env/
+
+# IDEs and editors
+.idea/
+.vscode/
+
+# OS files
+.DS_Store

--- a/gcpri/__init__.py
+++ b/gcpri/__init__.py
@@ -1,0 +1,8 @@
+"""GCP Resource Inventory (GCPRI).
+
+Utilities for collecting a cross-project inventory of Google Cloud Platform
+resources using the Cloud Asset API.
+"""
+
+__version__ = "0.1.0"
+


### PR DESCRIPTION
## Summary
- ignore Python build artifacts and virtualenvs
- describe package and expose version string

## Testing
- `python -m py_compile gcpri/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684a8b32db1c8320a7c143f6926aaedf