### PR TITLE
Support folder/organization scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # GCPRI
 
 GCP Resource Inventory (GCPRI) is a simple utility for collecting an
-inventory of GCP resources across one or more projects. It uses the
+inventory of GCP resources across one or more scopes (projects, folders
+or organizations). It uses the
 [Cloud Asset API](https://cloud.google.com/asset-inventory/docs/apis) to
 query all resources and outputs the results as JSON or CSV.
 
@@ -34,11 +35,16 @@ gcloud asset search-all-resources --scope="projects/PROJECT_ID" --limit=1
 ## Usage
 
 ```bash
-python -m gcpri PROJECT_ID [ANOTHER_PROJECT] --output inventory.json
+python -m gcpri PROJECT_ID [ANOTHER_PROJECT] \
+    --folders FOLDER_ID [ANOTHER_FOLDER] \
+    --organizations ORG_ID [ANOTHER_ORG] \
+    --output inventory.json
 ```
 
-Use `--format csv` to output a CSV file instead of JSON.
-Pass `--verbose` to see informational logs during execution.
+Pass folder or organization IDs with the `--folders` and `--organizations`
+flags. Each may be specified multiple times. Use `--format csv` to output a
+CSV file instead of JSON. Pass `--verbose` to see informational logs during
+execution.
 
 ## License
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,6 @@ def test_list_assets_no_location():
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     main = importlib.import_module('gcpri.main')
 
-    records = main.list_assets('proj')
-    assert records == [{'asset_type': 'type', 'name': 'name', 'project': 'proj', 'location': None}]
+    records = main.list_assets('projects/proj')
+    assert records == [{'asset_type': 'type', 'name': 'name', 'scope': 'projects/proj', 'location': None}]
 


### PR DESCRIPTION
## Summary
- generalize `list_assets` to accept any Cloud Asset scope
- allow multiple projects, folders, or organizations in `main`
- update usage docs for new options
- adjust tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a9fcb48848320b418806c6ccdf3aa